### PR TITLE
Allow manual triggering of the release github action

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -3,6 +3,7 @@
 name: Image
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
     paths:


### PR DESCRIPTION
Currently the only way to trigger the release workflow is update the VERSION file. In case of an error in the workflow run, this complicates the process for running again.