### PR TITLE
Updating rbacs and logging error

### DIFF
--- a/controllers/appwrapper_controller.go
+++ b/controllers/appwrapper_controller.go
@@ -169,7 +169,7 @@ func (r *AppWrapperReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if !useMachineSets {
 		instascaleOCMSecret, err := kubeClient.CoreV1().Secrets(r.ConfigsNamespace).Get(context.Background(), "instascale-ocm-secret", metav1.GetOptions{})
 		if err != nil {
-			klog.Infof("Error getting instascale-ocm-secret from namespace %v - Error :  %v", r.ConfigsNamespace, err)
+			klog.Errorf("Error getting instascale-ocm-secret from namespace %v - Error :  %v", r.ConfigsNamespace, err)
 		}
 		ocmToken = string(instascaleOCMSecret.Data["token"])
 	}

--- a/controllers/appwrapper_controller.go
+++ b/controllers/appwrapper_controller.go
@@ -169,7 +169,7 @@ func (r *AppWrapperReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if !useMachineSets {
 		instascaleOCMSecret, err := kubeClient.CoreV1().Secrets(r.ConfigsNamespace).Get(context.Background(), "instascale-ocm-secret", metav1.GetOptions{})
 		if err != nil {
-			klog.Infof("Error getting instascale-ocm-secret from namespace %v", r.ConfigsNamespace)
+			klog.Infof("Error getting instascale-ocm-secret from namespace %v - Error :  %v", r.ConfigsNamespace, err)
 		}
 		ocmToken = string(instascaleOCMSecret.Data["token"])
 	}

--- a/deployment/instascale-clusterrole.yaml
+++ b/deployment/instascale-clusterrole.yaml
@@ -53,6 +53,8 @@ rules:
 
 - apiGroups:
   - ""
+  resourceNames:
+    - instascale-ocm-secret
   resources:
     - secrets
   verbs:

--- a/deployment/instascale-clusterrole.yaml
+++ b/deployment/instascale-clusterrole.yaml
@@ -59,3 +59,11 @@ rules:
     - secrets
   verbs:
     - get
+
+- apiGroups:
+    - config.openshift.io
+  resources:
+    - clusterversions
+  verbs:
+    - get
+    - list

--- a/deployment/instascale-clusterrole.yaml
+++ b/deployment/instascale-clusterrole.yaml
@@ -50,3 +50,10 @@ rules:
   - update 
   - delete
   - patch
+
+- apiGroups:
+  - ""
+  resources:
+    - secrets
+  verbs:
+    - get


### PR DESCRIPTION
Resolves #81 

While working through the quick start [guide](https://github.com/opendatahub-io/distributed-workloads/blob/main/Quick-Start.md) instascale logs showed that the instascale-ocm-secret could not be found.
I updated the rbacs to include secrets. I also updated the error log to include the related error in the output.
