### PR TITLE
Use controller-runtime to consume Machine API

### DIFF
--- a/controllers/appWrapper_controller_test.go
+++ b/controllers/appWrapper_controller_test.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestDiscoverInstanceTypes(t *testing.T) {
+func (r *AppWrapperReconciler) TestDiscoverInstanceTypes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	tests := []struct {
@@ -99,7 +99,7 @@ func TestDiscoverInstanceTypes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := discoverInstanceTypes(test.input)
+			result := r.discoverInstanceTypes(test.input)
 			g.Expect(result).To(gomega.Equal(test.expected))
 		})
 	}

--- a/controllers/appwrapper_controller.go
+++ b/controllers/appwrapper_controller.go
@@ -255,12 +255,20 @@ func (r *AppWrapperReconciler) findExactMatch(ctx context.Context, aw *arbv1.App
 	}
 	var existingAcquiredMachineTypes = ""
 
+	for key, value := range aw.Labels {
+		if key == "orderedinstance" {
+			existingAcquiredMachineTypes = value
+		}
+	}
+
 	for _, eachAw := range appwrappers.Items {
 		if eachAw.Status.State != arbv1.AppWrapperStateEnqueued {
-			continue
+			if eachAw.Labels["orderedinstance"] == existingAcquiredMachineTypes {
+				match = &eachAw
+				klog.Infof("Found exact match, %v appwrapper has acquired machinetypes %v", eachAw.Name, existingAcquiredMachineTypes)
+				break
+			}
 		}
-		match = &eachAw
-		klog.Infof("Found exact match, %v appwrapper has acquired machinetypes %v", eachAw.Name, existingAcquiredMachineTypes)
 	}
 	return match
 

--- a/controllers/machinepools.go
+++ b/controllers/machinepools.go
@@ -156,16 +156,14 @@ func machinePoolExists() (bool, error) {
 }
 
 // getOCMClusterID determines the internal clusterID to be used for OCM API calls
-func getOCMClusterID(r *AppWrapperReconciler) error {
+func (r *AppWrapperReconciler) getOCMClusterID(ctx context.Context) error {
 	cv := &configv1.ClusterVersion{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "version"}, cv)
+	err := r.Get(ctx, types.NamespacedName{Name: "version"}, cv)
 	if err != nil {
 		return fmt.Errorf("can't get clusterversion: %v", err)
 	}
 
 	internalClusterID := string(cv.Spec.ClusterID)
-
-	ctx := context.Background()
 
 	connection, err := createOCMConnection()
 	if err != nil {

--- a/controllers/machinepools.go
+++ b/controllers/machinepools.go
@@ -35,32 +35,6 @@ func createOCMConnection() (*ocmsdk.Connection, error) {
 	return connection, nil
 }
 
-func scaleMachinePool(aw *arbv1.AppWrapper, userRequestedInstanceType string, replicas int) {
-	connection, err := createOCMConnection()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error creating OCM connection: %v", err)
-		return
-	}
-	defer connection.Close()
-
-	clusterMachinePools := connection.ClustersMgmt().V1().Clusters().Cluster(ocmClusterID).MachinePools()
-
-	m := make(map[string]string)
-	m[aw.Name] = aw.Name
-
-	machinePoolID := strings.ReplaceAll(aw.Name+"-"+userRequestedInstanceType, ".", "-")
-	createMachinePool, err := cmv1.NewMachinePool().ID(machinePoolID).InstanceType(userRequestedInstanceType).Replicas(replicas).Labels(m).Build()
-	if err != nil {
-		klog.Errorf(`Error building MachinePool: %v`, err)
-	}
-	klog.Infof("Built MachinePool with instance type %v and name %v", userRequestedInstanceType, createMachinePool.ID())
-	response, err := clusterMachinePools.Add().Body(createMachinePool).SendContext(context.Background())
-	if err != nil {
-		klog.Errorf(`Error creating MachinePool: %v`, err)
-	}
-	klog.Infof("Created MachinePool: %v", response)
-}
-
 func hasAwLabel(machinePool *cmv1.MachinePool, aw *arbv1.AppWrapper) bool {
 	labels := machinePool.Labels()
 	for key, value := range labels {

--- a/controllers/machinepools.go
+++ b/controllers/machinepools.go
@@ -36,11 +36,9 @@ func createOCMConnection() (*ocmsdk.Connection, error) {
 }
 
 func hasAwLabel(machinePool *cmv1.MachinePool, aw *arbv1.AppWrapper) bool {
-	labels := machinePool.Labels()
-	for key, value := range labels {
-		if key == aw.Name && value == aw.Name {
-			return true
-		}
+	value, ok := machinePool.Labels()[aw.Name]
+	if ok && value == aw.Name {
+		return true
 	}
 	return false
 }

--- a/controllers/machineset.go
+++ b/controllers/machineset.go
@@ -6,85 +6,65 @@ import (
 	"strings"
 	"time"
 
+	"strconv"
+
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	arbv1 "github.com/project-codeflare/multi-cluster-app-dispatcher/pkg/apis/controller/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func scaleMachineSet(aw *arbv1.AppWrapper, userRequestedInstanceType string, replicas int) {
-	allMachineSet, err := msLister.MachineSets("").List(labels.Everything())
+var (
+	isScaled = false
+)
+
+func (r *AppWrapperReconciler) checkExistingMachineSet(ctx context.Context, machineSetName string) bool {
+	// Set up the Object key with the requested app wrapper name and requested type
+	key := client.ObjectKey{
+		Name:      machineSetName,
+		Namespace: namespaceToList,
+	}
+
+	machineSet := &machinev1beta1.MachineSet{}
+	err := r.Get(ctx, key, machineSet)
+	if err != nil {
+		// Check if the error is due to the MachineSet not existing
+		if client.IgnoreNotFound(err) != nil {
+			// return error if it there is a different error for not getting the MachineSet
+			klog.Infof("Error getting MachineSet: %s", err)
+		}
+		// MachineSet does not exist
+		return false
+	}
+	// The MachineSet exists
+	return true
+}
+
+func (r *AppWrapperReconciler) reconcileCreateMachineSet(ctx context.Context, aw *arbv1.AppWrapper, demandMapPerInstanceType map[string]int) (ctrl.Result, error) {
+
+	allMachineSet := machinev1beta1.MachineSetList{}
+	err := r.List(ctx, &allMachineSet)
 	if err != nil {
 		klog.Infof("Error listing a machineset, %v", err)
 	}
-	for _, aMachineSet := range allMachineSet {
-		providerConfig, err := ProviderSpecFromRawExtension(aMachineSet.Spec.Template.Spec.ProviderSpec.Value)
-		if err != nil {
-			klog.Infof("Error retrieving provider config %v", err)
-		}
-		if userRequestedInstanceType == providerConfig.InstanceType {
 
-			if reuse {
+	for userRequestedInstanceType := range demandMapPerInstanceType {
+		for _, aMachineSet := range allMachineSet.Items {
+			providerConfig, err := ProviderSpecFromRawExtension(aMachineSet.Spec.Template.Spec.ProviderSpec.Value)
+			if err != nil {
+				klog.Infof("Error retrieving provider config %v", err)
+			}
+			if userRequestedInstanceType == providerConfig.InstanceType {
+				labelSelector := labels.SelectorFromSet(labels.Set(map[string]string{
+					aw.Name: aw.Name,
+				}))
 				copyOfaMachineSet := aMachineSet.DeepCopy()
-				additionalReplicas := int32(replicas)
-				existingReplicas := *copyOfaMachineSet.Spec.Replicas
-				totalReplicas := additionalReplicas + existingReplicas
-				copyOfaMachineSet.Spec.Replicas = &totalReplicas
-
-				allExistingMachines, errm := machineClient.MachineV1beta1().Machines(namespaceToList).List(context.Background(), metav1.ListOptions{})
-				if errm != nil {
-					klog.Infof("Error creating machineset: %v", errm)
-				}
-				var existingMachinesOwned []string
-				for _, machine := range allExistingMachines.Items {
-					for k, v := range machine.Labels {
-						//klog.Infof("looking for key %v", k)
-						if k == "machine.openshift.io/cluster-api-machineset" {
-							//klog.Infof("looking for value %v", v)
-							machinePhase := *machine.Status.Phase
-							if v == copyOfaMachineSet.Name && !contains(existingMachinesOwned, v) && (machinePhase != "Deleting") {
-								existingMachinesOwned = append(existingMachinesOwned, machine.Name)
-							}
-						}
-					}
-				}
-				klog.Infof("Existing machines owned in %s are %v", copyOfaMachineSet.Name, existingMachinesOwned)
-
-				//copyOfaMachineSet.ResourceVersion = ""
-				ms, err := machineClient.MachineV1beta1().MachineSets(namespaceToList).Update(context.Background(), copyOfaMachineSet, metav1.UpdateOptions{})
-				if err != nil {
-					klog.Infof("Error updating machineset %v", err)
-					return
-				}
-				//wait until all replicas are available
-				for (totalReplicas - ms.Status.AvailableReplicas) != 0 {
-					//TODO: user can delete appwrapper work on triggering scale-down
-					klog.Infof("REUSE: waiting for machines to be in state Ready. replicas needed: %v and replicas available: %v", totalReplicas, ms.Status.AvailableReplicas)
-					time.Sleep(1 * time.Minute)
-					ms, _ = machineClient.MachineV1beta1().MachineSets(namespaceToList).Get(context.Background(), copyOfaMachineSet.Name, metav1.GetOptions{})
-					klog.Infof("REUSE: Querying machineset %v to get updated replicas", ms.Name)
-				}
-				addedMachines, errm := machineClient.MachineV1beta1().Machines(namespaceToList).List(context.Background(), metav1.ListOptions{})
-				if errm != nil {
-					klog.Infof("Error listing machineset: %v", errm)
-				}
-				for _, machine := range addedMachines.Items {
-					for k, v := range machine.Labels {
-						if k == "machine.openshift.io/cluster-api-machineset" {
-							if !contains(existingMachinesOwned, machine.Name) && v == copyOfaMachineSet.Name {
-								nodeName := machine.Status.NodeRef.Name
-								addLabelToMachine(aw, machine.Name)
-								addLabelToNode(aw, nodeName)
-							}
-						}
-					}
-				}
-				return
-			} else {
-				copyOfaMachineSet := aMachineSet.DeepCopy()
-				replicas := int32(replicas)
+				replicas := int32(demandMapPerInstanceType[userRequestedInstanceType])
 				copyOfaMachineSet.Spec.Replicas = &replicas
 				copyOfaMachineSet.ResourceVersion = ""
 				copyOfaMachineSet.Spec.Template.Spec.Taints = []corev1.Taint{{Key: aw.Name, Value: "value1", Effect: "PreferNoSchedule"}}
@@ -98,82 +78,451 @@ func scaleMachineSet(aw *arbv1.AppWrapper, userRequestedInstanceType string, rep
 				copyOfaMachineSet.Spec.Selector = metav1.LabelSelector{
 					MatchLabels: workerLabels,
 				}
-				copyOfaMachineSet.Labels["aw"] = aw.Name
-				ms, err := machineClient.MachineV1beta1().MachineSets(namespaceToList).Create(context.Background(), copyOfaMachineSet, metav1.CreateOptions{})
-				if err != nil {
+				copyOfaMachineSet.Labels["instascale.codeflare.dev/aw"] = aw.Name
+
+				if err := r.Create(ctx, copyOfaMachineSet); err != nil {
 					klog.Infof("Error creating machineset %v", err)
-					return
+				} else {
+					return ctrl.Result{Requeue: true, RequeueAfter: 5 * time.Second}, nil
 				}
+
 				//wait until all replicas are available
-				for (replicas - ms.Status.AvailableReplicas) != 0 {
-					//TODO: user can delete appwrapper work on triggering scale-down
-					klog.Infof("waiting for machines to be in state Ready. replicas needed: %v and replicas available: %v", replicas, ms.Status.AvailableReplicas)
-					time.Sleep(1 * time.Minute)
-					ms, _ = machineClient.MachineV1beta1().MachineSets(namespaceToList).Get(context.Background(), copyOfaMachineSet.Name, metav1.GetOptions{})
-					klog.Infof("Querying machineset %v to get updated replicas", ms.Name)
+				if (replicas - copyOfaMachineSet.Status.AvailableReplicas) != 0 {
+					klog.Infof("waiting for machines to be in state Ready. replicas needed: %v and replicas available: %v", replicas, copyOfaMachineSet.Status.AvailableReplicas)
+					klog.Infof("Querying machineset %v to get updated replicas", copyOfaMachineSet.Name)
+					return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
 				}
-				klog.Infof("Machines are available. replicas needed: %v and replicas available: %v", replicas, ms.Status.AvailableReplicas)
-				allMachines, errm := machineClient.MachineV1beta1().Machines(namespaceToList).List(context.Background(), metav1.ListOptions{})
-				if errm != nil {
-					klog.Infof("Error creating machineset: %v", errm)
+				klog.Infof("Machines are available. replicas needed: %v and replicas available: %v", replicas, copyOfaMachineSet.Status.AvailableReplicas)
+				allMachines := machinev1beta1.MachineList{}
+				err = r.List(ctx, &allMachines)
+				if err != nil {
+					klog.Infof("Error listing machines: %v", err)
 				}
 				//map machines to machinesets?
 				//for non-reuse case labels can be added directly to machineset: https://github.com/openshift/machine-api-operator/issues/1077
+				listOptions := &client.ListOptions{
+					LabelSelector: labelSelector,
+				}
+				err = r.List(ctx, &allMachines, listOptions)
+				if err != nil {
+					klog.Infof("Error listing machines: %v", err)
+				}
 				for idx := range allMachines.Items {
 					machine := &allMachines.Items[idx]
-					for k, _ := range machine.Labels {
-						if k == aw.Name {
+					nodeName := machine.Status.NodeRef.Name
+					labelPatch := fmt.Sprintf(`[{"op":"add","path":"/metadata/labels/%s","value":"%s" }]`, aw.Name, aw.Name)
+					ms, err := r.kubeClient.CoreV1().Nodes().Patch(context.Background(), nodeName, types.JSONPatchType, []byte(labelPatch), metav1.PatchOptions{})
+					if err != nil {
+						klog.Infof("Error patching label to Node: %v", err)
+					}
+					if len(ms.Labels) > 0 && err == nil {
+						klog.Infof("label added to node %v, for scaling %v", nodeName, copyOfaMachineSet.Name)
+					}
+				}
+			}
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *AppWrapperReconciler) filterAwMachines(ctx context.Context, aw *arbv1.AppWrapper, userRequestedInstanceType string) []string {
+	labelSelector := labels.SelectorFromSet(labels.Set(map[string]string{
+		aw.Name:                              aw.Name,
+		"machine.openshift.io/instance-type": userRequestedInstanceType,
+	}))
+	listOptions := &client.ListOptions{
+		LabelSelector: labelSelector,
+	}
+
+	machinesWithAwLabel := machinev1beta1.MachineList{}
+	err := r.List(ctx, &machinesWithAwLabel, listOptions)
+	if err != nil {
+		klog.Infof("Error listing machines: %s", err)
+	}
+	var runningAwMachines []string
+	for _, machine := range machinesWithAwLabel.Items {
+		machinePhase := machine.Status.Phase
+		if *machinePhase == "Running" {
+			runningAwMachines = append(runningAwMachines, machine.Name)
+		}
+	}
+	return runningAwMachines
+}
+
+func (r *AppWrapperReconciler) filterAllRunningAwMachines(ctx context.Context, aw *arbv1.AppWrapper) []string {
+	labelSelector := labels.SelectorFromSet(labels.Set(map[string]string{
+		aw.Name: aw.Name,
+	}))
+	listOptions := &client.ListOptions{
+		LabelSelector: labelSelector,
+	}
+	machinesWithAwLabel := machinev1beta1.MachineList{}
+	var allRunningAwMachines []string
+	err := r.List(ctx, &machinesWithAwLabel, listOptions)
+	if err != nil {
+		klog.Infof("Error listing machines: %s", err)
+	}
+
+	for _, machine := range machinesWithAwLabel.Items {
+		machinePhase := machine.Status.Phase
+		if *machinePhase != "Deleting" {
+			allRunningAwMachines = append(allRunningAwMachines, machine.Name)
+		}
+	}
+	return allRunningAwMachines
+}
+
+func (r *AppWrapperReconciler) canScaleMachineset(ctx context.Context, aw *arbv1.AppWrapper, demandPerInstanceType map[string]int) bool {
+	//control plane can include any number of nodes
+	//we count how many additional nodes can be added to the cluster
+
+	allRunningAwMachines := r.filterAllRunningAwMachines(ctx, aw)
+
+	var totalNodesAddedByMachinesets int32 = 0
+
+	totalNodesAddedByMachinesets += int32(len(allRunningAwMachines))
+
+	for _, count := range demandPerInstanceType {
+		totalNodesAddedByMachinesets += int32(count)
+	}
+	if totalNodesAddedByMachinesets >= int32(maxScaleNodesAllowed) {
+		klog.Infof("Scaling not possible: The nodes allowed %v and total nodes in cluster after node scale-out %v", maxScaleNodesAllowed, totalNodesAddedByMachinesets)
+	}
+	return totalNodesAddedByMachinesets <= int32(maxScaleNodesAllowed)
+}
+
+func (r *AppWrapperReconciler) reconcileReuseMachineSet(ctx context.Context, aw *arbv1.AppWrapper, demandMapPerInstanceType map[string]int) (ctrl.Result, error) {
+	var runningAwMachines []string
+
+	// Gather a list of all MachineSets
+	allMachineSets := machinev1beta1.MachineSetList{}
+	if err := r.List(ctx, &allMachineSets); err != nil {
+		klog.Infof("Error listing MachineSets: %s", err)
+	}
+
+	for userRequestedInstanceType := range demandMapPerInstanceType {
+		// Iterate over each MachineSet in the allMachineSets list
+		for _, aMachineSet := range allMachineSets.Items {
+			// Get the MachineSet's instance type
+			providerConfig, err := ProviderSpecFromRawExtension(aMachineSet.Spec.Template.Spec.ProviderSpec.Value)
+			if err != nil {
+				klog.Infof("Error retrieving provider config %v", err)
+			}
+			// Label selector for gettings machines of requested type and app wrapper label
+			labelSelector := labels.SelectorFromSet(labels.Set(map[string]string{
+				aw.Name:                              aw.Name,
+				"machine.openshift.io/instance-type": userRequestedInstanceType,
+			}))
+			listOptions := &client.ListOptions{
+				LabelSelector: labelSelector,
+			}
+			// Compare this MachineSet's instance type with the user requested instance type
+			if userRequestedInstanceType == providerConfig.InstanceType {
+				// Get a list of running machines with the AppWrapper label
+				runningAwMachines = r.filterAwMachines(ctx, aw, userRequestedInstanceType)
+				// Calculate what the new total number of replicas should be
+				copyOfaMachineSet := aMachineSet.DeepCopy()
+				replicas := demandMapPerInstanceType[userRequestedInstanceType]
+				existingReplicas := int32(*copyOfaMachineSet.Spec.Replicas) - int32(len(runningAwMachines))
+				totalReplicas := int32(replicas) + existingReplicas
+				copyOfaMachineSet.Spec.Replicas = &totalReplicas
+
+				// Check if MachineSet has replica label already and set isScaled = true
+				for k, v := range aMachineSet.Labels {
+					if k == fmt.Sprintf("instascale.codeflare.dev/%s", aw.Name) {
+						if v == strconv.FormatInt(int64(replicas), 10) {
+							isScaled = true
+						}
+					}
+				}
+
+				// Label Selector which will list machines that belong to the specific Machine Set
+				instanceLabelSelector := labels.SelectorFromSet(labels.Set(map[string]string{
+					"machine.openshift.io/instance-type":          userRequestedInstanceType,
+					"machine.openshift.io/cluster-api-machineset": aMachineSet.Name,
+				}))
+				instanceListOptions := &client.ListOptions{
+					LabelSelector: instanceLabelSelector,
+				}
+
+				// List all machines currently in the specific MachineSet
+				allExistingMachinesInMs := machinev1beta1.MachineList{}
+				if err := r.List(ctx, &allExistingMachinesInMs, instanceListOptions); err != nil {
+					klog.Infof("Error listing Machines: %s", err)
+				}
+
+				/*
+				   A for loop that will list machines with the AppWrapper label and apply the label
+				   if the count of machines with labels does not match the number of requested replicas
+				*/
+				machinesWithAwLabel := machinev1beta1.MachineList{}
+				if len(allExistingMachinesInMs.Items) > 0 {
+					for _, machine := range allExistingMachinesInMs.Items {
+						err := r.List(ctx, &machinesWithAwLabel, listOptions)
+						if err != nil {
+							klog.Infof("Error listing machines: %v", err)
+						}
+						machinePhase := machine.Status.Phase
+
+						if len(machinesWithAwLabel.Items) != replicas && (*machinePhase == "Running") {
 							nodeName := machine.Status.NodeRef.Name
-							labelPatch := fmt.Sprintf(`[{"op":"add","path":"/metadata/labels/%s","value":"%s" }]`, aw.Name, aw.Name)
-							ms, err := kubeClient.CoreV1().Nodes().Patch(context.Background(), nodeName, types.JSONPatchType, []byte(labelPatch), metav1.PatchOptions{})
-							if len(ms.Labels) > 0 && err == nil {
-								klog.Infof("label added to node %v, for scaling %v", nodeName, copyOfaMachineSet.Name)
+							r.addLabelToMachine(ctx, aw, machine.Name)
+							r.addLabelToNode(ctx, aw, nodeName)
+						}
+					}
+				}
+
+				// Get a list of running machines with the AppWrapper label
+				runningAwMachines = r.filterAwMachines(ctx, aw, userRequestedInstanceType)
+				canScaleMachineSets := r.canScaleMachineset(ctx, aw, demandMapPerInstanceType)
+				if (!isScaled || len(runningAwMachines) != replicas) && canScaleMachineSets {
+					// A loop to get the names of existing machines in the MachineSet
+					var existingMachinesOwned []string
+					for _, machine := range allExistingMachinesInMs.Items {
+						machinePhase := machine.Status.Phase
+						if !contains(existingMachinesOwned, machine.Name) && (*machinePhase != "Deleting") {
+							existingMachinesOwned = append(existingMachinesOwned, machine.Name)
+						}
+					}
+					klog.Infof("Existing machines owned in %s are %v", copyOfaMachineSet.Name, existingMachinesOwned)
+
+					// Apply the requested replica count label to the MachineSet
+					copyOfaMachineSet.Labels[fmt.Sprintf("instascale.codeflare.dev/%s", aw.Name)] = strconv.FormatInt(int64(replicas), 10)
+
+					// If the MachineSet's requested replica count label is not equal to the requested replica count then the machineSet must be updated
+					if aMachineSet.Labels[fmt.Sprintf("instascale.codeflare.dev/%s", aw.Name)] != strconv.FormatInt(int64(replicas), 10) {
+						if strconv.FormatInt(int64(replicas), 10) < aMachineSet.Labels[fmt.Sprintf("instascale.codeflare.dev/%s", aw.Name)] {
+							r.removeMachinesBasedOnReplicas(ctx, aw, userRequestedInstanceType, int(replicas))
+						} else {
+							klog.Infof("The instanceRequired array: %v", userRequestedInstanceType)
+							if err := r.Update(ctx, copyOfaMachineSet); err != nil {
+								klog.Infof("Error updating MachineSet: %s", err)
+							}
+							klog.Infof("Updated MachineSet: %s", copyOfaMachineSet.Name)
+						}
+						return ctrl.Result{Requeue: true}, nil
+					}
+					/*
+						A conditional statement which will make sure that if the number of requested replicas != to number of scaled machines
+						a message is printed to the console and the Reconcile method is called after 30 seconds
+					*/
+					if replicas != len(runningAwMachines) {
+						klog.Infof("REUSE: waiting for machines to be in state Ready. replicas needed: %v and replicas available: %v", replicas, len(runningAwMachines))
+						return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
+					}
+				}
+			}
+		}
+		continue
+	}
+	return ctrl.Result{}, nil
+}
+
+// This function exists for scenarios where the user has altered the number of replicas requested on the AppWrapper
+func (r *AppWrapperReconciler) removeMachinesBasedOnReplicas(ctx context.Context, aw *arbv1.AppWrapper, userRequestedInstanceType string, replicas int) (ctrl.Result, error) {
+	// We get a list of Nodes with the AppWrapper name and correct instance type
+	labelSelector := labels.SelectorFromSet(labels.Set(map[string]string{
+		aw.Name:                            aw.Name,
+		"node.kubernetes.io/instance-type": userRequestedInstanceType,
+	}))
+	listOptions := &metav1.ListOptions{
+		LabelSelector: labelSelector.String(),
+	}
+	nodes, _ := r.kubeClient.CoreV1().Nodes().List(context.TODO(), *listOptions)
+
+	// We get the number of running labeled machines
+	numberOfmachines := len(r.filterAwMachines(ctx, aw, userRequestedInstanceType))
+	// A "while" loop that compares the number of replicas to the number of labeled machines
+	for replicas < numberOfmachines {
+		for _, node := range nodes.Items {
+			if replicas == numberOfmachines {
+				break
+			}
+			klog.Infof("Filtered Node name: %s", node.Name)
+			// We get the machine annotation from the node in order to get the machine's name
+			for k, v := range node.Annotations {
+				if k == "machine.openshift.io/machine" {
+					machineName := strings.Split(v, "/")
+					klog.Infof("The machine name to be annotated %v", machineName[1])
+
+					// Get the specific machine that owns this node
+					nodeMachine := &machinev1beta1.Machine{}
+					if err := r.Get(ctx, types.NamespacedName{Name: machineName[1], Namespace: namespaceToList}, nodeMachine); err != nil {
+						klog.Infof("Error getting machine: %s", err)
+					}
+
+					updateMachine := nodeMachine.DeepCopy()
+					updateMachine.Annotations["machine.openshift.io/cluster-api-delete-machine"] = "true"
+					if err := r.Update(ctx, updateMachine); err != nil {
+						klog.Infof("Error updating Machine: %s", err)
+					}
+					klog.Infof("Successfully updated %s", updateMachine.Name)
+
+					// Get the MachineSet name of the specific Machine
+					var updateMachinesetName string = ""
+					for k, v := range updateMachine.Labels {
+						if k == "machine.openshift.io/cluster-api-machineset" {
+							updateMachinesetName = v
+							klog.Infof("Machineset to update is %v", updateMachinesetName)
+						}
+					}
+
+					if updateMachinesetName != "" {
+						allMachineSet := machinev1beta1.MachineSetList{}
+						if err := r.List(ctx, &allMachineSet); err != nil {
+							klog.Infof("Error listing MachineSets: %s", err)
+						}
+						for _, aMachineSet := range allMachineSet.Items {
+							if aMachineSet.Name == updateMachinesetName {
+								klog.Infof("Existing machineset replicas %v", *aMachineSet.Spec.Replicas)
+								// Scale down 1 replica per loop iteration
+								newReplicas := *aMachineSet.Spec.Replicas - int32(1)
+								updateMsReplicas := aMachineSet.DeepCopy()
+								updateMsReplicas.Spec.Replicas = &newReplicas
+								// Update the label to reflect new number of replicas
+								updateMsReplicas.Labels[fmt.Sprintf("instascale.codeflare.dev/%s", aw.Name)] = strconv.FormatInt(int64(replicas), 10)
+
+								if err := r.Update(ctx, updateMsReplicas); err != nil {
+									klog.Infof("Error updating MachineSet: %s", err)
+								}
+								klog.Infof("Successfully removed node and updated MachineSet")
+								numberOfmachines = numberOfmachines - 1
+
+								return ctrl.Result{Requeue: true}, nil
 							}
 						}
 					}
 				}
-				return
 			}
+		}
+		break
+	}
+	return ctrl.Result{}, nil
+}
 
+func (r *AppWrapperReconciler) annotateToDeleteMachine(ctx context.Context, aw *arbv1.AppWrapper) {
+	nodes, _ := r.kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+
+	for _, node := range nodes.Items {
+		for k := range node.Labels {
+			//get nodes that have AW name as key
+			if k == aw.Name {
+				klog.Infof("Filtered node name is %v", aw.Name)
+				for k, v := range node.Annotations {
+					if k == "machine.openshift.io/machine" {
+						machineName := strings.Split(v, "/")
+						klog.Infof("The machine name to be annotated %v", machineName[1])
+						allMachines := machinev1beta1.MachineList{}
+						errm := r.List(ctx, &allMachines)
+						if errm != nil {
+							klog.Infof("Error listing machines: %v", errm)
+						}
+						for _, aMachine := range allMachines.Items {
+							//remove index hardcoding
+							updateMachine := aMachine.DeepCopy()
+							if aMachine.Name == machineName[1] {
+								updateMachine.Annotations["machine.openshift.io/cluster-api-delete-machine"] = "true"
+								err := r.Update(ctx, updateMachine)
+								if err == nil {
+									klog.Infof("update successful")
+								}
+								var updateMachineset string = ""
+								for k, v := range updateMachine.Labels {
+									if k == "machine.openshift.io/cluster-api-machineset" {
+										updateMachineset = v
+										klog.Infof("Machineset to update is %v", updateMachineset)
+									}
+								}
+								if updateMachineset != "" {
+									allMachineSet := machinev1beta1.MachineSetList{}
+									err := r.List(ctx, &allMachineSet)
+									if err != nil {
+										klog.Infof("Machineset retrieval error")
+									}
+									for _, aMachineSet := range allMachineSet.Items {
+										if aMachineSet.Name == updateMachineset {
+											klog.Infof("Existing machineset replicas %v", aMachineSet.Spec.Replicas)
+											//scale down is harded coded to 1??
+											newReplicas := *aMachineSet.Spec.Replicas - int32(1)
+											updateMsReplicas := aMachineSet.DeepCopy()
+											updateMsReplicas.Spec.Replicas = &newReplicas
+											err := r.Update(ctx, updateMsReplicas)
+											if err == nil {
+												klog.Infof("Replica update successful")
+											}
+											r.removeMachineSetLabel(ctx, aw, aMachineSet.Name)
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
 		}
 	}
 }
 
-func addLabelToMachine(aw *arbv1.AppWrapper, machineName string) {
+func (r *AppWrapperReconciler) addLabelToMachine(ctx context.Context, aw *arbv1.AppWrapper, machineName string) {
 	labelPatch := fmt.Sprintf(`[{"op":"add","path":"/metadata/labels/%s","value":"%s" }]`, aw.Name, aw.Name)
-	_, err := machineClient.MachineV1beta1().Machines(namespaceToList).Patch(context.Background(), machineName, types.JSONPatchType, []byte(labelPatch), metav1.PatchOptions{})
+	patchBytes := []byte(labelPatch)
+
+	// Retrieve the machine object
+	machine := &machinev1beta1.Machine{}
+	err := r.Get(ctx, types.NamespacedName{Name: machineName, Namespace: namespaceToList}, machine)
 	if err != nil {
-		klog.Infof("Error adding label to machines %v", err)
+		klog.Infof("Error retrieving machine: %v", err)
+		return
+	}
+
+	// Apply the patch to add the label
+	patch := client.RawPatch(types.JSONPatchType, patchBytes)
+	err = r.Patch(ctx, machine, patch)
+	if err != nil {
+		klog.Infof("Error adding label to machine: %v", err)
 	}
 }
 
-func addLabelToNode(aw *arbv1.AppWrapper, nodeName string) {
+func (r *AppWrapperReconciler) addLabelToNode(ctx context.Context, aw *arbv1.AppWrapper, nodeName string) {
 	labelPatch := fmt.Sprintf(`[{"op":"add","path":"/metadata/labels/%s","value":"%s" }]`, aw.Name, aw.Name)
-	_, err := kubeClient.CoreV1().Nodes().Patch(context.Background(), nodeName, types.JSONPatchType, []byte(labelPatch), metav1.PatchOptions{})
+	_, err := r.kubeClient.CoreV1().Nodes().Patch(ctx, nodeName, types.JSONPatchType, []byte(labelPatch), metav1.PatchOptions{})
 	if err != nil {
 		klog.Infof("Error adding label to machine %v", err)
 	}
 }
 
-func removeLabelFromMachine(aw *arbv1.AppWrapper, machineName string) {
+func (r *AppWrapperReconciler) removeLabelFromMachine(ctx context.Context, aw *arbv1.AppWrapper, machineName string) {
 	labelPatch := fmt.Sprintf(`[{"op":"remove","path":"/metadata/labels/%s","value":"%s" }]`, aw.Name, aw.Name)
-	_, err := machineClient.MachineV1beta1().Machines(namespaceToList).Patch(context.Background(), machineName, types.JSONPatchType, []byte(labelPatch), metav1.PatchOptions{})
+	patchBytes := []byte(labelPatch)
+	// Retrieve the machine object
+	machine := &machinev1beta1.Machine{}
+	err := r.Get(ctx, types.NamespacedName{Name: machineName, Namespace: namespaceToList}, machine)
 	if err != nil {
-		klog.Infof("deleted label to machines %v", err)
+		klog.Infof("Error retrieving machine: %v", err)
+		return
+	}
+
+	// Apply the patch to remove the label
+	patch := client.RawPatch(types.JSONPatchType, patchBytes)
+	err = r.Patch(ctx, machine, patch)
+	if err != nil {
+		klog.Infof("Error removing label from machine: %v", err)
 	}
 }
 
-func removeLabelFromNode(aw *arbv1.AppWrapper, nodeName string) {
+func (r *AppWrapperReconciler) removeLabelFromNode(aw *arbv1.AppWrapper, nodeName string) {
 	labelPatch := fmt.Sprintf(`[{"op":"remove","path":"/metadata/labels/%s","value":"%s" }]`, aw.Name, aw.Name)
-	_, err := kubeClient.CoreV1().Nodes().Patch(context.Background(), nodeName, types.JSONPatchType, []byte(labelPatch), metav1.PatchOptions{})
+	_, err := r.kubeClient.CoreV1().Nodes().Patch(context.Background(), nodeName, types.JSONPatchType, []byte(labelPatch), metav1.PatchOptions{})
 	if err != nil {
 		klog.Infof("Error deleted label to machines %v", err)
 	}
 }
 
 // add logic to swap out labels with new appwrapper label
-func swapNodeLabels(oldAw *arbv1.AppWrapper, newAw *arbv1.AppWrapper) {
-	allMachines, errm := machineClient.MachineV1beta1().Machines(namespaceToList).List(context.Background(), metav1.ListOptions{})
+func (r *AppWrapperReconciler) swapNodeLabels(ctx context.Context, oldAw *arbv1.AppWrapper, newAw *arbv1.AppWrapper) {
+	allMachines := machinev1beta1.MachineList{}
+	errm := r.List(ctx, &allMachines)
 	if errm != nil {
 		klog.Infof("Error creating machineset: %v", errm)
 	}
@@ -184,101 +533,49 @@ func swapNodeLabels(oldAw *arbv1.AppWrapper, newAw *arbv1.AppWrapper) {
 			if k == oldAw.Name {
 				nodeName := machine.Status.NodeRef.Name
 				klog.Infof("removing label from node %v that belonged to appwrapper %v and adding node to new appwrapper %v", nodeName, oldAw.Name, newAw.Name)
-				removeLabelFromMachine(oldAw, machine.Name)
-				removeLabelFromNode(oldAw, nodeName)
-				addLabelToMachine(newAw, machine.Name)
-				addLabelToNode(newAw, nodeName)
+				r.removeLabelFromMachine(ctx, oldAw, machine.Name)
+				r.removeLabelFromNode(oldAw, nodeName)
+				r.addLabelToMachine(ctx, newAw, machine.Name)
+				r.addLabelToNode(ctx, newAw, nodeName)
 			}
 		}
 	}
 }
 
-func deleteMachineSet(aw *arbv1.AppWrapper) {
-	var err error
-	allMachineSet, _ := msLister.MachineSets("").List(labels.Everything())
-	for _, aMachineSet := range allMachineSet {
-		//klog.Infof("%v.%v", aMachineSet.Name, aw.Name)
-		if strings.Contains(aMachineSet.Name, aw.Name) {
-			//klog.Infof("Deleting machineset named %v", aw.Name)
-			err = machineClient.MachineV1beta1().MachineSets(namespaceToList).Delete(context.Background(), aMachineSet.Name, metav1.DeleteOptions{})
-			if err == nil {
-				klog.Infof("Delete successful")
-			}
-		}
-	}
-}
-
-func canScaleMachineset(demandPerInstanceType map[string]int) bool {
-	//control plane can include any number of nodes
-	//we count how many additional nodes can be added to the cluster
-	var totalNodesAddedByMachinesets int32 = 0
-	allMachineSet, err := msLister.MachineSets("").List(labels.Everything())
+func (r *AppWrapperReconciler) removeMachineSetLabel(ctx context.Context, aw *arbv1.AppWrapper, machineSetName string) {
+	// Retrieve the machineSet object
+	machineSet := &machinev1beta1.MachineSet{}
+	err := r.Get(ctx, types.NamespacedName{Name: machineSetName, Namespace: namespaceToList}, machineSet)
 	if err != nil {
-		klog.Infof("Error listing a machineset, %v", err)
+		klog.Infof("Error retrieving MachineSet: %v", err)
+		return
 	}
-	for _, aMachine := range allMachineSet {
-		totalNodesAddedByMachinesets += *aMachine.Spec.Replicas
+
+	labelPatch := fmt.Sprintf(`[{"op":"remove","path":"/metadata/labels/instascale.codeflare.dev~1%s" }]`, aw.Name)
+	patchBytes := []byte(labelPatch)
+
+	// Apply the patch to remove the label
+	patch := client.RawPatch(types.JSONPatchType, patchBytes)
+	err = r.Patch(ctx, machineSet, patch)
+	if err != nil {
+		klog.Infof("Error removing label from MachineSet: %v", err)
 	}
-	for _, count := range demandPerInstanceType {
-		totalNodesAddedByMachinesets += int32(count)
-	}
-	klog.Infof("The nodes allowed: %v and total nodes in cluster after node scale-out %v", maxScaleNodesAllowed, totalNodesAddedByMachinesets)
-	return totalNodesAddedByMachinesets <= int32(maxScaleNodesAllowed)
 }
 
-func annotateToDeleteMachine(aw *arbv1.AppWrapper) {
-	nodes, _ := kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
-
-	for _, node := range nodes.Items {
-		for k, _ := range node.Labels {
-			//get nodes that have AW name as key
-			if k == aw.Name {
-				klog.Infof("Filtered node name is %v", aw.Name)
-				for k, v := range node.Annotations {
-					if k == "machine.openshift.io/machine" {
-						machineName := strings.Split(v, "/")
-						klog.Infof("The machine name to be annotated %v", machineName[1])
-						allMachines, _ := machineClient.MachineV1beta1().Machines(namespaceToList).List(context.Background(), metav1.ListOptions{})
-						for _, aMachine := range allMachines.Items {
-							//remove index hardcoding
-							updateMachine := aMachine.DeepCopy()
-							if aMachine.Name == machineName[1] {
-								updateMachine.Annotations["machine.openshift.io/cluster-api-delete-machine"] = "true"
-								machine, err := machineClient.MachineV1beta1().Machines(namespaceToList).Update(context.Background(), updateMachine, metav1.UpdateOptions{})
-								if err == nil {
-									klog.Infof("update successful")
-								}
-								var updateMachineset string = ""
-								for k, v := range machine.Labels {
-									if k == "machine.openshift.io/cluster-api-machineset" {
-										updateMachineset = v
-									}
-									klog.Infof("Machineset to update is %v", updateMachineset)
-								}
-								if updateMachineset != "" {
-									allMachineSet, err := msLister.MachineSets("").List(labels.Everything())
-									if err != nil {
-										klog.Infof("Machineset retrieval error")
-									}
-									for _, aMachineSet := range allMachineSet {
-										if aMachineSet.Name == updateMachineset {
-											klog.Infof("Existing machineset replicas %v", aMachineSet.Spec.Replicas)
-											//scale down is harded coded to 1??
-											newReplicas := *aMachineSet.Spec.Replicas - int32(1)
-											updateMsReplicas := aMachineSet.DeepCopy()
-											updateMsReplicas.Spec.Replicas = &newReplicas
-											_, err = machineClient.MachineV1beta1().MachineSets(namespaceToList).Update(context.Background(), updateMsReplicas, metav1.UpdateOptions{})
-											if err == nil {
-												klog.Infof("Replica update successful")
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				}
+func (r *AppWrapperReconciler) deleteMachineSet(ctx context.Context, aw *arbv1.AppWrapper) {
+	allMachineSet := machinev1beta1.MachineSetList{}
+	err := r.List(ctx, &allMachineSet)
+	if err != nil {
+		klog.Infof("Error listing MachineSets: %v", allMachineSet)
+	}
+	for _, aMachineSet := range allMachineSet.Items {
+		if strings.Contains(aMachineSet.Name, aw.Name) {
+			klog.Infof("Deleting machineset named %v", aw.Name)
+			err := r.Delete(ctx, &aMachineSet)
+			if err != nil {
+				klog.Infof("Failed to delete machine set: %v", err)
 			}
+			klog.Infof("Deleted MachineSet: %v", aw.Name)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -30,16 +30,19 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/project-codeflare/instascale/controllers"
 	"github.com/project-codeflare/instascale/pkg/config"
+
 	// +kubebuilder:scaffold:imports
 	mcadv1beta1 "github.com/project-codeflare/multi-cluster-app-dispatcher/pkg/apis/controller/v1beta1"
 )
@@ -56,8 +59,8 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(configv1.Install(scheme))
-
-	// +kubebuilder:scaffold:scheme
+	utilruntime.Must(machinev1beta1.Install(scheme))
+	//+kubebuilder:scaffold:scheme
 	_ = mcadv1beta1.AddToScheme(scheme)
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,7 +27,7 @@ type InstaScaleConfiguration struct {
 	// maxScaleoutAllowed defines the upper limit for the number of cluster nodes
 	// that can be scaled out by InstaScale.
 	MaxScaleoutAllowed int32 `json:"maxScaleoutAllowed"`
-	// reuse is a bool which is used to decide if machineSets are created from a copy
-	// or reused by instascale
-	Reuse bool `json:"reuse,omitempty"`
+	// machineSetsStrategy is a string which is used to decide if machineSets are created from a copy
+	// or reused by instascale by using either the Reuse or Duplicate string.
+	MachineSetsStrategy string `json:"machineSetsStrategy,omitempty"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,4 +27,7 @@ type InstaScaleConfiguration struct {
 	// maxScaleoutAllowed defines the upper limit for the number of cluster nodes
 	// that can be scaled out by InstaScale.
 	MaxScaleoutAllowed int32 `json:"maxScaleoutAllowed"`
+	// reuse is a bool which is used to decide if machineSets are created from a copy
+	// or reused by instascale
+	Reuse bool `json:"reuse,omitempty"`
 }


### PR DESCRIPTION
Closes: #53 
## Verification Steps
### OSD Cluster - Machine Pools
* Scale machines using InstaScale
*  Delete the AppWrapper to trigger the scaling down steps
InstaScale should work as expected
### Self Managed/OCP Cluster - MachineSets
* Follow this [guide](https://github.com/project-codeflare/instascale#scaling-machines-with-a-self-managed-ocp-cluster-using-aws) for creating MachineSet Templates
* Scale Machines using InstaScale
*  Delete the AppWrapper to trigger the scaling down steps
InstaScale should work as expected

Note: At the moment when scaling up and down errors about updating the appwrapper will appear in the console due to an issue with applying/removing the finalizer