### PR TITLE
add: coverage report generation to test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,16 +78,17 @@ test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 	grep -v -e "_moq.go" cover.out > coverage.out
 
-test/output/coverage/report:
-	@if [ -f coverage.out ]; then $(GO) tool cover -func=coverage.out; else echo "coverage.out file not found"; fi;
-.PHONY: test/output/coverage/report
+coverage.out: test
 
-test/html/coverage/report:
-	@if [ -f coverage.out ]; then $(GO) tool cover -html=coverage.out; else echo "coverage.out file not found"; fi;
-.PHONY: test/html/coverage/report
+coverage-report: coverage.out
+	$(GO) tool cover -func=coverage.out
+.PHONY: coverage-report
+
+html-coverage-report: coverage.out
+	$(GO) tool cover -html=coverage.out
+.PHONY: html-coverage-report
 
 ##@ Build
-
 .PHONY: build
 build: generate fmt vet ## Build manager binary.
 	go build -o bin/manager main.go

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
 
+GO ?= go
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -74,6 +76,15 @@ vet: ## Run go vet against code.
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	grep -v -e "_moq.go" cover.out > coverage.out
+
+test/output/coverage/report:
+	@if [ -f coverage.out ]; then $(GO) tool cover -func=coverage.out; else echo "coverage.out file not found"; fi;
+.PHONY: test/output/coverage/report
+
+test/html/coverage/report:
+	@if [ -f coverage.out ]; then $(GO) tool cover -html=coverage.out; else echo "coverage.out file not found"; fi;
+.PHONY: test/html/coverage/report
 
 ##@ Build
 


### PR DESCRIPTION
This PR modifies the 'test' target in the Makefile to generate a coverage report of tests.

This adds a visual line-by-line coverage of each function. Aimed at assisting with future testing within the codebase.

To test out the functionality:
First run ``` make test ```  

Then either:
``` make html-coverage-report``` - opens a line by line report within your browser.
``` make coverage-report``` - prints a functional coverage percentage report in the terminal.

Resolves #99