### PR TITLE
add: Machine Pool existence check 

### DIFF
--- a/controllers/appWrapper_controller_test.go
+++ b/controllers/appWrapper_controller_test.go
@@ -86,7 +86,7 @@ func TestDiscoverInstanceTypes(t *testing.T) {
 			expected: map[string]int{},
 		},
 		{
-			name: "Test with empty orderedinstance",
+			name: "Test with no orderedinstance",
 			input: &arbv1.AppWrapper{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/controllers/appwrapper_controller.go
+++ b/controllers/appwrapper_controller.go
@@ -47,6 +47,7 @@ type AppWrapperReconciler struct {
 	client.Client
 	Scheme           *runtime.Scheme
 	ConfigsNamespace string
+	OcmSecretNamespace string
 }
 
 var (
@@ -167,9 +168,9 @@ func (r *AppWrapperReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	if !useMachineSets {
-		instascaleOCMSecret, err := kubeClient.CoreV1().Secrets(r.ConfigsNamespace).Get(context.Background(), "instascale-ocm-secret", metav1.GetOptions{})
+		instascaleOCMSecret, err := kubeClient.CoreV1().Secrets(r.OcmSecretNamespace).Get(context.Background(), "instascale-ocm-secret", metav1.GetOptions{})
 		if err != nil {
-			klog.Errorf("Error getting instascale-ocm-secret from namespace %v - Error :  %v", r.ConfigsNamespace, err)
+			klog.Errorf("Error getting instascale-ocm-secret from namespace %v: %v", r.OcmSecretNamespace, err)
 		}
 		ocmToken = string(instascaleOCMSecret.Data["token"])
 	}

--- a/controllers/machinepools.go
+++ b/controllers/machinepools.go
@@ -104,15 +104,10 @@ func machinePoolExists() bool {
 		os.Exit(1)
 	}
 	defer connection.Close()
-	connection.ClustersMgmt().V1().Clusters().Cluster(ocmClusterID).NodePools().Add()
 
-	clusterMachinePools := connection.ClustersMgmt().V1().Clusters().Cluster(ocmClusterID).MachinePools()
-	klog.Infof("cluster machine pools %v", clusterMachinePools)
-	if clusterMachinePools != nil {
-		klog.Infof("Machine pools are present %v", clusterMachinePools)
-		return true
-	}
-	return false
+	machinePools := connection.ClustersMgmt().V1().Clusters().Cluster(ocmClusterID).MachinePools()
+	klog.Infof("Machine pools: %v", machinePools)
+	return machinePools != nil
 }
 
 // getOCMClusterID determines the internal clusterID to be used for OCM API calls

--- a/controllers/machinepools.go
+++ b/controllers/machinepools.go
@@ -86,6 +86,35 @@ func deleteMachinePool(aw *arbv1.AppWrapper) {
 	})
 }
 
+// Check if machine pools exist
+func machinePoolExists() bool {
+	logger, err := ocmsdk.NewGoLoggerBuilder().
+		Debug(false).
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build logger: %v\n", err)
+		os.Exit(1)
+	}
+	connection, err := ocmsdk.NewConnectionBuilder().
+		Logger(logger).
+		Tokens(ocmToken).
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build connection: %v\n", err)
+		os.Exit(1)
+	}
+	defer connection.Close()
+	connection.ClustersMgmt().V1().Clusters().Cluster(ocmClusterID).NodePools().Add()
+
+	clusterMachinePools := connection.ClustersMgmt().V1().Clusters().Cluster(ocmClusterID).MachinePools()
+	klog.Infof("cluster machine pools %v", clusterMachinePools)
+	if clusterMachinePools != nil {
+		klog.Infof("Machine pools are present %v", clusterMachinePools)
+		return true
+	}
+	return false
+}
+
 // getOCMClusterID determines the internal clusterID to be used for OCM API calls
 func getOCMClusterID(r *AppWrapperReconciler) error {
 

--- a/deployment/instascale-clusterrole.yaml
+++ b/deployment/instascale-clusterrole.yaml
@@ -67,3 +67,4 @@ rules:
   verbs:
     - get
     - list
+    - watch

--- a/main.go
+++ b/main.go
@@ -85,9 +85,9 @@ func main() {
 	}
 
 	if err = (&controllers.AppWrapperReconciler{
-		Client:           mgr.GetClient(),
-		Scheme:           mgr.GetScheme(),
-		ConfigsNamespace: configsNamespace,
+		Client:             mgr.GetClient(),
+		Scheme:             mgr.GetScheme(),
+		ConfigsNamespace:   configsNamespace,
 		OcmSecretNamespace: ocmSecretNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AppWrapper")

--- a/main.go
+++ b/main.go
@@ -55,9 +55,11 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var configsNamespace string
+	var ocmSecretNamespace string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.StringVar(&configsNamespace, "configs-namespace", "kube-system", "The namespace containing the InstaScale configmap and OCM secret")
+	flag.StringVar(&configsNamespace, "configs-namespace", "kube-system", "The namespace containing the Instacale configmap")
+	flag.StringVar(&ocmSecretNamespace, "ocm-secret-namespace", "default", "The namespace containing the OCM secret")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -86,6 +88,7 @@ func main() {
 		Client:           mgr.GetClient(),
 		Scheme:           mgr.GetScheme(),
 		ConfigsNamespace: configsNamespace,
+		OcmSecretNamespace: ocmSecretNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AppWrapper")
 		os.Exit(1)


### PR DESCRIPTION
This pr adds a machinePoolExists which checks if machine pools are present in the cluster. This is used to determine between the use of Machine Pools and Machine Sets.

This change also contains an updated namespace for the ocm secret.