### PR TITLE
fix: allow for download of kustomize from the makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Key features:
 - To build locally : `make build`
 - To run locally : `make run`
 ## Image creation
-- To build and release a docker image for controller : `make IMG=quay.io/project-codeflare/instascale:<TAG> docker-build docker-push`
+- To build and release a docker image for controller : `make IMG=quay.io/project-codeflare/instascale:<TAG> image-build image-push`
 - Note that the other contents of the Makefile (as well as the `config` and `bin` dirs) exist for future operator development, and are not currently utilized
 ## Deployment
 - Deploy InstaScale using: `make deploy`


### PR DESCRIPTION
# Issue link
#134


# What changes have been made
This pr fixes contains the addition of go-get-tool to download  kustomize and setup-envtest if they are not currently locally installed. 

It also contains a change to the declaration of the image to use for deployment. The image was being set to `controller:latest` when running `make deploy`. It will now be set to `quay.io/project-codeflare/instascale-controller:latest`

# Verification steps

Previously:
Within instascale, go to /bin and delete your kustomize binary.
Then from the root folder, run `make kustomize`. The Kustomize binary will not have been downloaded.

This branch: 
Within instascale, go to /bin and delete your kustomize binary.
Then from the root folder, run `make kustomize`. The Kustomize binary will be downloaded.

## Checks
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
