### PR TITLE
Add make target for custom-deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,11 @@ endif
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
+# custom-deploy can be used for building and pushing a custom image of InstaScale and deploying it on your K8s cluster for development.
+# Example: "make custom-deploy ENGINE=<podman or docker> IMG=quay.io/<username>/instascale:<image tag>"
+.PHONY: custom-deploy
+custom-deploy: image-build image-push install deploy
+
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -

--- a/README.md
+++ b/README.md
@@ -32,7 +32,13 @@ Key features:
 - To build and release a docker image for controller : `make IMG=quay.io/project-codeflare/instascale:<TAG> image-build image-push`
 - Note that the other contents of the Makefile (as well as the `config` and `bin` dirs) exist for future operator development, and are not currently utilized
 ## Deployment
-- Deploy InstaScale using: `make deploy`
+- Deploy InstaScale (latest) using: `make deploy`
+
+- Optionally, to deploy a custom image of InstaScale you can use the `custom-deploy` make target to build, push, and deploy your image of InstaScale on your Kubernetes cluster:
+```
+make custom-deploy ENGINE=<podman or docker> IMG=quay.io/<username>/instascale:<image tag>
+```
+Note: This assumes you are logged into your quay.io account on your local machine, and your kubeconfig is pointing to the cluster you want to deploy InstaScale on.
 
 ## Running an InstaScale deployment locally with Visual Studio Code
 - Deploy MCAD using steps [here](https://github.com/project-codeflare/multi-cluster-app-dispatcher/blob/main/doc/deploy/deployment.md).


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Closes #152

The changes here are similar to what is done in this [PR for MCAD](https://github.com/project-codeflare/multi-cluster-app-dispatcher/pull/639)  

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
- The `custom-deploy` make target can be used for building and pushing a custom image of InstaScale and deploying it on your K8s cluster for development.
- Added documentation to Readme.

Note: using the name `custom-deploy` for the make target as there is already an existing easy way of deploying InstaScale (latest) to your K8s cluster. This make target focuses on the custom image deployments.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Example: `make custom-deploy ENGINE=<podman or docker> IMG=quay.io/<username>/instascale:<image tag>`


## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Manual tests

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->