### PR TITLE
Remove automatic triage/needs-triage label creation

### DIFF
--- a/.github/workflows/auto-add-issues.yml
+++ b/.github/workflows/auto-add-issues.yml
@@ -1,20 +1,9 @@
-name: Label new issues as needs-triage and add to CodeFlare Sprint Board
+name: Add new issues to CodeFlare Sprint Board
 on:
   issues:
     types:
       - opened
 jobs:
-  add_label:
-    name: Add needs-triage label to new issues
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - uses: actions/checkout@v3
-      - run: gh issue edit ${{ github.event.issue.number }} --add-label "triage/needs-triage"
-        env:
-          GH_TOKEN: ${{ github.token }}
-
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Remove workflow job adding triage/needs-triage label for new issues. Currently the triage is leveraging priority field.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->