### PR TITLE
Machines not scaling due to ID character limit

### DIFF
--- a/controllers/appwrapper_controller.go
+++ b/controllers/appwrapper_controller.go
@@ -43,14 +43,15 @@ type MachineType string
 // AppWrapperReconciler reconciles a AppWrapper object
 type AppWrapperReconciler struct {
 	client.Client
-	Scheme        *runtime.Scheme
-	Config        config.InstaScaleConfiguration
-	kubeClient    *kubernetes.Clientset
-	ocmClusterID  string
-	ocmToken      string
-	ocmConnection *ocmsdk.Connection
-	MachineType   MachineType
-	machineCheck  bool
+	Scheme                    *runtime.Scheme
+	Config                    config.InstaScaleConfiguration
+	kubeClient                *kubernetes.Clientset
+	ocmClusterID              string
+	ocmToken                  string
+	ocmConnection             *ocmsdk.Connection
+	MachineType               MachineType
+	machineCheck              bool
+	machineNameCharacterLimit int
 }
 
 var (
@@ -247,6 +248,7 @@ func (r *AppWrapperReconciler) setMachineType(ctx context.Context) error {
 	}
 	if hypershiftEnabled {
 		r.MachineType = MachineTypeNodePool
+		r.machineNameCharacterLimit = 15
 	}
 	return nil
 }
@@ -256,6 +258,7 @@ func (r *AppWrapperReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 
 	logger := ctrl.LoggerFrom(ctx)
 	restConfig := mgr.GetConfig()
+	r.machineNameCharacterLimit = 30
 
 	var err error
 	r.kubeClient, err = kubernetes.NewForConfig(restConfig)


### PR DESCRIPTION
# Issue link
closes https://github.com/project-codeflare/instascale/issues/143

# What changes have been made

This Pr is for 320e5f0e47e0a0211ecc8765930b3ef4ff2ff46a and will be rebased after [Hypershift Integration](https://github.com/project-codeflare/instascale/pull/129) has been merged.

This pr contains an update to the nodepools, and machinepool ID generation convention for instascale. Replacing the appended instance-type with a string of 4 random characters.

The prefix is the appwrapper name (Truncated if over the character limit when appended to the suffix, Nodepools 15, MachinePools 30). 

This change also updates the scaledown functions to scaledown machines with a label pointing to the related appwrapper (composed of the appwrapper name, and namespace), as apposed to the machine ID.



These changes also rely on the codeflare-operator e2e tests being updated. 

# Verification steps
Dispatch an appwrapper (with a long name :) ) on hypershift and OSD with instascale enabled and a specified instance type. 

Ensure the machine scales up as expected, and the machine name is truncated to a suitable character length.
Ensure the machine scales down once complete. 

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->