### PR TITLE
add: appwrapper pending status and condition check for scale-up

### DIFF
--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	machinev1 "github.com/openshift/api/machine/v1beta1"
+	arbv1 "github.com/project-codeflare/multi-cluster-app-dispatcher/pkg/apis/controller/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -17,6 +19,15 @@ func resyncPeriod() func() time.Duration {
 		factor := rand.Float64() + 1
 		return time.Duration(float64(minResyncPeriod.Nanoseconds()) * factor)
 	}
+}
+
+func containsInsufficientCondition(allconditions []arbv1.AppWrapperCondition) bool {
+	for _, condition := range allconditions {
+		if strings.Contains(condition.Message, "Insufficient") {
+			return true
+		}
+	}
+	return false
 }
 
 // ProviderSpecFromRawExtension unmarshals the JSON-encoded spec


### PR DESCRIPTION
# Issue link
Closes: https://issues.redhat.com/browse/RHOAIENG-861

# What changes have been made
This pr contains an update to ensure the AW is in a pending state, with a condition of Insufficient resources before scaling up the specified resources for the appwrapper. This ensure resource usage efficiency for the cluster. 

# Verification steps
Steps I have followed to ensure the functionality. On a cluster with 2 m6i.2xlarge worker nodes. 

I provisioned an appwrapper which required more resources than available on the cluster. 

```yaml
    - custompodresources:
      - limits:
          cpu: 10
          memory: 40G
          nvidia.com/gpu: 0
        replicas: 2
        requests:
          cpu: 10
          memory: 40G
          nvidia.com/gpu: 0
      - limits:
          cpu: 10
          memory: 40G
          nvidia.com/gpu: 1
        replicas: 
        requests:
          cpu: 10
          memory: 40G 
          nvidia.com/gpu: 1
```

This ensured the aw would reach pending state with the condition on Insufficient resources, inducing a scale up of the specified resources, as can be seen here: 

![ScaleUp](https://github.com/project-codeflare/instascale/assets/34043122/dc255d8a-9071-43b5-9e7b-95d2f112ac01)

I also provisioned an appwrapper with required resources within the clusters available

```yaml
    - custompodresources:
      - limits:
          cpu: 2
          memory: 8G
          nvidia.com/gpu: 0
        replicas: 1
        requests:
          cpu: 2
          memory: 8G
          nvidia.com/gpu: 0
      - limits:
          cpu: 2
          memory: 8G
          nvidia.com/gpu: 1
        replicas: 2
        requests:
          cpu: 2
          memory: 8G
          nvidia.com/gpu: 1
```

With this the appwrapper was dispatched without the need for scaling up. As can be seen in the following:
![NoScaleUp](https://github.com/project-codeflare/instascale/assets/34043122/1a37e1a6-55fd-44b5-8c4d-4a1038f90572)



## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->